### PR TITLE
"type Wchar int32" should be "type Wchar uint16" on Windows 

### DIFF
--- a/wchar.go
+++ b/wchar.go
@@ -4,9 +4,6 @@ import (
 	"unsafe"
 )
 
-// go representation of a wchar
-type Wchar int32
-
 // return pointer to this Wchar
 func (w Wchar) Pointer() *Wchar {
 	return &w

--- a/wchar_notwin.go
+++ b/wchar_notwin.go
@@ -1,0 +1,6 @@
+// +build !windows
+
+package wchar
+
+// go representation of a wchar
+type Wchar int32

--- a/wchar_windows.go
+++ b/wchar_windows.go
@@ -1,0 +1,4 @@
+package wchar
+
+// go representation of a wchar
+type Wchar uint16


### PR DESCRIPTION
... in order to compile. (Otherwise we hit a lots of failed casts)
