### PR TITLE
ARM build support

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -55,7 +55,7 @@ func convertGoStringToWcharString(input string) (output WcharString, err error) 
 	defer C.free(unsafe.Pointer(inputCString))
 
 	// create output buffer
-	outputChars := make([]int8, len(input)*4)
+	outputChars := make(OutputChars, len(input)*4)
 
 	// output for C
 	outputCString := (*C.char)(&outputChars[0])
@@ -66,7 +66,7 @@ func convertGoStringToWcharString(input string) (output WcharString, err error) 
 		return nil, errno
 	}
 
-	// convert []int8 to WcharString
+	// convert OutputChars to WcharString
 	// create WcharString with same length as input, and one extra position for the null terminator.
 	output = make(WcharString, 0, len(input)+1)
 	// create buff to convert each outputChar
@@ -257,7 +257,7 @@ func convertWcharToGoRune(w Wchar) (output rune, err error) {
 		return '\000', errno
 	}
 
-	// convert outputChars ([]int8, len 4) to Wchar
+	// convert outputChars (OutputChars, len 4) to Wchar
 	// TODO: can this conversion be done easier by using this: ?
 	// output = *((*rune)(unsafe.Pointer(&outputChars[0])))
 	runeAsByteAry := make([]byte, 4)

--- a/convert_arm.go
+++ b/convert_arm.go
@@ -1,0 +1,5 @@
+// +build arm
+
+package wchar
+
+type OutputChars []uint8

--- a/convert_other.go
+++ b/convert_other.go
@@ -1,0 +1,5 @@
+// +build !arm
+
+package wchar
+
+type OutputChars []int8

--- a/wchar_arm.go
+++ b/wchar_arm.go
@@ -1,6 +1,6 @@
-// +build !windows
+// +build arm
 
 package wchar
 
 // go representation of a wchar
-type Wchar int32
+type Wchar uint32

--- a/wchar_other.go
+++ b/wchar_other.go
@@ -1,6 +1,6 @@
-// +build windows
+// +build !windows,!arm
 
 package wchar
 
 // go representation of a wchar
-type Wchar uint16
+type Wchar int32


### PR DESCRIPTION
I have no idea what I'm doing and I could't get the tests to pass on linux/amd64 or darwin/amd64 from the master branch, but this seems to work..
#### Change outputChars type for ARM builds

This fixes the following error for me when cross-compiling this project for
linux/arm on linux/amd64:

```
CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ CGO_ENABLED=1 GOARCH=arm GOARM=7 go build
# github.com/GeertJohan/cgo.wchar
../../GeertJohan/cgo.wchar/convert.go:61: cannot convert &outputChars[0] (type *int8) to type *C.char
```
#### Change Wchar type for ARM builds

This fixes the following error for me when cross-compiling GeertJohan/go.hid
for linux/arm on linux/amd64:

```
CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ CGO_ENABLED=1 GOARCH=arm GOARM=7 go build
# github.com/GeertJohan/go.hid
../../GeertJohan/go.hid/hid.go:271: cannot convert serialNumberWchar.Pointer() (type *wchar.Wchar) to type *C.wchar_t
../../GeertJohan/go.hid/hid.go:597: cannot convert ws.Pointer() (type *wchar.Wchar) to type *C.wchar_t
../../GeertJohan/go.hid/hid.go:624: cannot convert ws.Pointer() (type *wchar.Wchar) to type *C.wchar_t
../../GeertJohan/go.hid/hid.go:651: cannot convert ws.Pointer() (type *wchar.Wchar) to type *C.wchar_t
../../GeertJohan/go.hid/hid.go:679: cannot convert ws.Pointer() (type *wchar.Wchar) to type *C.wchar_t
```
